### PR TITLE
Fix package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ numpy>=1.19.2
 pandas>=1.0.1
 scipy>=1.4.1
 torch>=1.7.0,!=1.8
+tensorflow_text==2.6.0
 transformers>=3.3.0
 terminaltables
 tqdm>=4.27,<4.50.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ filelock
 language_tool_python
 lemminflect
 lru-dict
-datasets
+datasets==1.11.0
 nltk
 numpy>=1.19.2
 pandas>=1.0.1


### PR DESCRIPTION
Fix package versions so that `textattack` can be `pip-compile`'d

PR that depends on this: https://github.com/discord/discord/pull/50859