### PR TITLE
Avoid downloading word embeddings at class init time

### DIFF
--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -19,15 +19,19 @@ class ThoughtVector(SentenceEncoder):
         word_embedding (textattack.shared.AbstractWordEmbedding): The word embedding to use
     """
 
-    def __init__(
-        self, embedding=WordEmbedding.counterfitted_GLOVE_embedding(), **kwargs
-    ):
+    def __init__(self, embedding=None, **kwargs):
         if not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
                 "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )
-        self.word_embedding = embedding
+        self._word_embedding = embedding
         super().__init__(**kwargs)
+
+    @property
+    def word_embedding(self):
+        if self._word_embedding is None:
+            self._word_embedding = WordEmbedding.counterfitted_GLOVE_embedding()
+        return self._word_embedding
 
     def clear_cache(self):
         self._get_thought_vector.cache_clear()

--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -20,7 +20,7 @@ class ThoughtVector(SentenceEncoder):
     """
 
     def __init__(self, embedding=None, **kwargs):
-        if not isinstance(embedding, AbstractWordEmbedding):
+        if embedding is not None and not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
                 "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )

--- a/textattack/constraints/semantics/word_embedding_distance.py
+++ b/textattack/constraints/semantics/word_embedding_distance.py
@@ -24,7 +24,7 @@ class WordEmbeddingDistance(Constraint):
 
     def __init__(
         self,
-        embedding=WordEmbedding.counterfitted_GLOVE_embedding(),
+        embedding=None,
         include_unknown_words=True,
         min_cos_sim=None,
         max_mse_dist=None,
@@ -40,11 +40,17 @@ class WordEmbeddingDistance(Constraint):
         self.min_cos_sim = min_cos_sim
         self.max_mse_dist = max_mse_dist
 
-        if not isinstance(embedding, AbstractWordEmbedding):
+        if embedding is not None and not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
                 "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )
-        self.embedding = embedding
+        self._embedding = embedding
+
+    @property
+    def embedding(self):
+        if self._embedding is None:
+            self._embedding = WordEmbedding.counterfitted_GLOVE_embedding()
+        return self._embedding
 
     def get_cos_sim(self, a, b):
         """Returns the cosine similarity of words with IDs a and b."""

--- a/textattack/transformations/word_swaps/word_swap_embedding.py
+++ b/textattack/transformations/word_swaps/word_swap_embedding.py
@@ -21,19 +21,20 @@ class WordSwapEmbedding(WordSwap):
         embedding (textattack.shared.AbstractWordEmbedding): Wrapper for word embedding
     """
 
-    def __init__(
-        self,
-        max_candidates=15,
-        embedding=WordEmbedding.counterfitted_GLOVE_embedding(),
-        **kwargs
-    ):
+    def __init__(self, max_candidates=15, embedding=None, **kwargs):
         super().__init__(**kwargs)
         self.max_candidates = max_candidates
-        if not isinstance(embedding, AbstractWordEmbedding):
+        if embedding is not None and not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
                 "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )
-        self.embedding = embedding
+        self._embedding = embedding
+
+    @property
+    def embedding(self):
+        if self._embedding is None:
+            self._embedding = WordEmbedding.counterfitted_GLOVE_embedding()
+        return self._embedding
 
     def _get_replacement_words(self, word):
         """Returns a list of possible 'candidate words' to replace a word in a


### PR DESCRIPTION
The previous behavior (i.e. downloading embeddings at init time) causes pods to OOM with our current memory config