### PR TITLE
WIP: Stop mistakenly logging errors to gcloud logging

### DIFF
--- a/textattack/shared/utils/install.py
+++ b/textattack/shared/utils/install.py
@@ -155,12 +155,14 @@ def _post_install():
     logger.info("Downloading NLTK required packages.")
     import nltk
 
-    nltk.download("averaged_perceptron_tagger")
-    nltk.download("stopwords")
-    nltk.download("omw")
-    nltk.download("universal_tagset")
-    nltk.download("wordnet")
-    nltk.download("punkt")
+    # nltk.download prints plain text to stderr without a severity indicator,
+    # which gcloud logging identifies as an error, so suppress information output here
+    nltk.download("averaged_perceptron_tagger", quiet=True)
+    nltk.download("stopwords", quiet=True)
+    nltk.download("omw", quiet=True)
+    nltk.download("universal_tagset", quiet=True)
+    nltk.download("wordnet", quiet=True)
+    nltk.download("punkt", quiet=True)
 
     try:
         import stanza


### PR DESCRIPTION
discord_ai_nlp tasks that import textattack generate the following plain text to stderr:

```
textattack: Updating TextAttack package dependencies.
textattack: Downloading NLTK required packages.
[nltk_data] Downloading package averaged_perceptron_tagger to
[nltk_data]     /home/user/nltk_data...
[nltk_data]   Unzipping taggers/averaged_perceptron_tagger.zip.
[nltk_data] Downloading package stopwords to /home/user/nltk_data...
[nltk_data]   Package stopwords is already up-to-date!
[nltk_data] Downloading package omw to /home/user/nltk_data...
[nltk_data]   Unzipping corpora/omw.zip.
[nltk_data] Downloading package universal_tagset to
[nltk_data]     /home/user/nltk_data...
[nltk_data]   Unzipping taggers/universal_tagset.zip.
[nltk_data] Downloading package wordnet to /home/user/nltk_data...
[nltk_data]   Unzipping corpora/wordnet.zip.
[nltk_data] Downloading package punkt to /home/user/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
```
For example https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.namespace_name%3D%22argo-20210730%22%0Aresource.labels.container_name%3D%22main%22%0Aresource.labels.pod_name%3D%2220211113-025334-3949014604%22%0Aseverity%3DERROR;timeRange=2021-11-13T02:59:34Z%2F2021-11-13T03:23:50Z;cursorTimestamp=2021-11-13T03:01:35.831378316Z?project=discord-data-stg

These lines are tagged as severity: ERROR by gcloud logging by default because they don't contain a parse-able severity indicator, and they cause all such workflow tasks to be flagged as erroneous even when they run fine. This makes it hard to determine if there were really errors in a given workflow.

Fix false positive errors by stopping textattack and nltk from printing this to stderr.